### PR TITLE
Fixing the browser type with the generic 

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -61,7 +61,7 @@ type Result = MultiResult | (ImageCompareResult | number)
 
 declare global {
     namespace WebdriverIO {
-        interface Browser {
+        interface Browser<Mode> {
             /**
              * Saves an image of an element
              */


### PR DESCRIPTION
Instead of going with BrowserAsync which caused issues for people, using the generic that WDIO uses which is `Browser<Mode>`. This seems to work for me when using `Browser<"async">` as well as `Browser<"sync">` which was the default in WDIO 7 and prior. In WDIO 8 they have deprecated `"sync"` but some of the types remain.