### PR TITLE
fix(service.js): apply the current browser object

### DIFF
--- a/lib/service.js
+++ b/lib/service.js
@@ -33,7 +33,7 @@ export default class WdioImageComparisonService extends BaseClass {
      *
      * @param {Array.<Object>} capabilities list of capabilities details
      */
-    before(capabilities) {
+    before(capabilities, specs, browser) {
         if (typeof capabilities['browserName'] !== 'undefined') {
             log.info('Adding commands to global browser')
             this.addCommandsToBrowser(capabilities, browser)


### PR DESCRIPTION
The global browser object was used though WebdriverIO v8 supports importing the globals manually. This commit applies the current browser object that has all the properties it needs.